### PR TITLE
Update main.js

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -156,6 +156,11 @@ import Utils from './utils';
          * If `true` is passed, it will show the progress bar even if its hidden.
          *
          *     MProgress.end(true);
+         * 
+         * Passing `true` for `instanteRemove` removes the progress loader without waiting for any delays
+         * 
+         *     MProgress.end(null, true);
+         * 
          */
         end: function(force, instantRemove) {
             if (!force && !this.status) return this;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -157,7 +157,7 @@ import Utils from './utils';
          *
          *     MProgress.end(true);
          */
-        end: function(force) {
+        end: function(force, instantRemove) {
             if (!force && !this.status) return this;
 
             var that    = this;
@@ -169,6 +169,11 @@ import Utils from './utils';
             }
 
             if (this._isIndeterminateStyle()) {
+                
+                // End without waiting for any delays
+                if (instantRemove) {
+                    return that._remove();
+                }
 
                 // force end
                 if(!this._isRendered() && force) {
@@ -328,7 +333,7 @@ import Utils from './utils';
             var progress = this._getRenderedId(),
             MParent   = document.querySelector(this.options.parent);
 
-            if (MParent != document.body) {
+            if (MParent && MParent != document.body) {
                 Utils.removeClass(MParent, 'mprogress-custom-parent');
             }
 


### PR DESCRIPTION
Currently there's no way to end a progress loader instantly, say for example the parent element gets removed before the `speed` delay completes, it will throw an error at `Utils.setcss` because there's no element to set the values to. Additionally subsequent calls trying to initialize MProgress fail from the previous errors.

It's very annoying to integrate into Frameworks like Angular that remove elements without warning. This update simply ignores the DOM element references if they don't exist.
