### PR TITLE
docs: Fix simple typo, proccess -> process

### DIFF
--- a/build/js/mprogress.js
+++ b/build/js/mprogress.js
@@ -489,7 +489,7 @@
                 var progress = this._getRenderedId(),
                 MParent   = document.querySelector(this.options.parent);
 
-                // stop this process if the progress was allready removed
+                // stop this process if the progress was already removed
                 if (!MParent) return;
 
                 if (MParent != document.body) {

--- a/build/js/mprogress.js
+++ b/build/js/mprogress.js
@@ -489,7 +489,7 @@
                 var progress = this._getRenderedId(),
                 MParent   = document.querySelector(this.options.parent);
 
-                // stop this proccess if the progress was allready removed
+                // stop this process if the progress was allready removed
                 if (!MParent) return;
 
                 if (MParent != document.body) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -328,7 +328,7 @@ import Utils from './utils';
             var progress = this._getRenderedId(),
             MParent   = document.querySelector(this.options.parent);
 
-            // stop this process if the progress was allready removed
+            // stop this process if the progress was already removed
             if (!MParent) return;
 
             if (MParent != document.body) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -328,7 +328,7 @@ import Utils from './utils';
             var progress = this._getRenderedId(),
             MParent   = document.querySelector(this.options.parent);
 
-            // stop this proccess if the progress was allready removed
+            // stop this process if the progress was allready removed
             if (!MParent) return;
 
             if (MParent != document.body) {


### PR DESCRIPTION
There is a small typo in build/js/mprogress.js, src/js/main.js.

Should read `process` rather than `proccess`.

